### PR TITLE
Fixup parameter to match plusargs

### DIFF
--- a/elf-loader.core
+++ b/elf-loader.core
@@ -1,6 +1,6 @@
 CAPI=1
 [main]
-name = ::elf-loader:1.0.2
+name = ::elf-loader:1.0.3
 description = Generic ELF loader
 
 [vpi]
@@ -13,7 +13,7 @@ src_files     = elf-loader.c
 include_files = elf-loader.h
 libs          = -lelf
 
-[parameter elf-load]
+[parameter elf_load]
 datatype    = file
 description = ELF file to preload to memory
 paramtype   = plusarg

--- a/elf-loader.core
+++ b/elf-loader.core
@@ -1,23 +1,44 @@
-CAPI=1
-[main]
-name = ::elf-loader:1.0.3
-description = Generic ELF loader
+CAPI=2:
 
-[vpi]
-src_files = elf-loader.c vpi_wrapper.c
-include_files = elf-loader.h
-libs = -lelf
+name : ::elf-loader:1.0.3
+description : Generic ELF loader
 
-[verilator]
-src_files     = elf-loader.c
-include_files = elf-loader.h
-libs          = -lelf
+filesets :
+  elf_loader :
+    files : [elf-loader.c, elf-loader.h : {is_include_file : true}]
+    file_type : cSource
 
-[parameter elf_load]
-datatype    = file
-description = ELF file to preload to memory
-paramtype   = plusarg
-scope       = public
+  vpi :
+    files : [vpi_wrapper.c]
+    file_type : cSource
 
-[scripts]
-pre_build_scripts = check_libelf.sh
+  check_libelf:
+    files: [check_libelf.sh : {file_type: user, copyto: check_libelf.sh}]
+
+vpi :
+  elf_loader_vpi :
+    filesets : [elf_loader, vpi]
+    libs : [elf]
+
+targets :
+  default :
+    hooks :
+      pre_build : [check_libelf]
+    filesets : ["tool_verilator? (elf_loader)", check_libelf]
+    parameters : ["!tool_verilator? (elf_load)"]  # for verilator the argument is --elf-load, not a plusarg
+    tools :
+      verilator :
+        libs : [-lelf]
+    vpi : [elf_loader_vpi]
+
+
+parameters :
+  elf_load :
+    datatype : file
+    description : ELF file to preload to memory
+    paramtype : plusarg
+    scope : public
+
+scripts :
+  check_libelf :
+    cmd : [/bin/sh, check_libelf.sh]


### PR DESCRIPTION
Due to recent changes in fusesoc/edalize it seems that the parameter
name elf-load no longer works.  Changing it to elf_load fixes the issue
also when running fusesoc we must pass the argument --elf_load instead
of --elf-load.

Without this we get errors:

    $ fusesoc run --target mor1kx_tb mor1kx-generic --elf-load
    ./native/build/or1k/or1k-jmp
    INFO: Preparing ::adv_debug_sys:3.1.0-r1
    INFO: Preparing ::cdc_utils:0.1
    INFO: Preparing ::elf-loader:1.0.2
    INFO: Preparing ::intgen:0
    INFO: Preparing ::jtag_tap:1.13-r1
    INFO: Preparing ::jtag_vpi:0-r4
    INFO: Preparing ::mor1kx:5.0-r3
    INFO: Preparing ::uart16550:1.5.5-r1
    INFO: Preparing ::verilog-arbiter:0-r2
    INFO: Preparing ::vlog_tb_utils:1.1
    INFO: Preparing ::wb_common:1.0.3
    INFO: Preparing ::wb_bfm:1.2.1
    INFO: Preparing ::wb_intercon:1.2.2
    INFO: Preparing ::wb_ram:1.1
    INFO: Preparing ::mor1kx-generic:1.1
    ERROR: Setup failed : Unknown parameter elf_load

There are many projects that use the elf_load plusarg, so I think
changing it here is better than every project.

    $ grep -r plus.*elf.load *
    de0_nano-multicore/bench/orpsoc_tb.v:   if($value$plusargs("elf_load=%s", elf_file)) begin
    micron-cores/dram/mt48lc16m16a2_wrapper.v:      if($value$plusargs("elf_load=%s", elf_file)) begin
    mor1kx-generic/bench/verilog/orpsoc_tb.v:      if($value$plusargs("elf_load=%s", elf_file)) begin
    wb_streamer/build/wb_sdram_ctrl/src/mt48lc16m16a2/mt48lc16m16a2_wrapper.v:      if($value$plusargs("elf_load=%s", elf_file)) begin